### PR TITLE
修改部门信息bug

### DIFF
--- a/src/main/java/com/stylefeng/guns/core/shiro/ShiroKit.java
+++ b/src/main/java/com/stylefeng/guns/core/shiro/ShiroKit.java
@@ -17,6 +17,7 @@ package com.stylefeng.guns.core.shiro;
 
 import com.stylefeng.guns.common.constant.Const;
 import com.stylefeng.guns.common.constant.factory.ConstantFactory;
+import com.stylefeng.guns.common.persistence.model.User;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.crypto.hash.Md5Hash;
 import org.apache.shiro.crypto.hash.SimpleHash;
@@ -274,7 +275,18 @@ public class ShiroKit {
      * 获取当前用户的部门数据范围的集合
      */
     public static List<Integer> getDeptDataScope() {
-        Integer deptId = getUser().getDeptId();
+        /*Integer deptId = getUser().getDeptId();
+        List<Integer> subDeptIds = ConstantFactory.me().getSubDeptId(deptId);
+        subDeptIds.add(deptId);
+        return subDeptIds;*/
+        return getDeptDataScope(null);
+    }
+
+    /**
+     * 获取当前用户的部门数据范围的集合
+     */
+    public static List<Integer> getDeptDataScope(User user) {
+        Integer deptId = user == null ? getUser().getDeptId() : user.getDeptid();
         List<Integer> subDeptIds = ConstantFactory.me().getSubDeptId(deptId);
         subDeptIds.add(deptId);
         return subDeptIds;

--- a/src/main/java/com/stylefeng/guns/modular/system/controller/UserMgrController.java
+++ b/src/main/java/com/stylefeng/guns/modular/system/controller/UserMgrController.java
@@ -157,7 +157,9 @@ public class UserMgrController extends BaseController {
     @Permission
     @ResponseBody
     public Object list(@RequestParam(required = false) String name, @RequestParam(required = false) String beginTime, @RequestParam(required = false) String endTime, @RequestParam(required = false) Integer deptid) {
-        DataScope dataScope = new DataScope(ShiroKit.getDeptDataScope());
+        Integer userId = ShiroKit.getUser().getId();
+        User user = userMapper.selectByPrimaryKey(userId);
+        DataScope dataScope = new DataScope(ShiroKit.getDeptDataScope(user));
         List<Map<String, Object>> users = userMapper.selectUsers(dataScope, name, beginTime, endTime, deptid);
         return new UserWarpper(users).warp();
     }
@@ -345,8 +347,8 @@ public class UserMgrController extends BaseController {
      * 判断当前登录的用户是否有操作这个用户的权限
      */
     private void assertAuth(Integer userId) {
-        List<Integer> deptDataScope = ShiroKit.getDeptDataScope();
         User user = userMapper.selectByPrimaryKey(userId);
+        List<Integer> deptDataScope = ShiroKit.getDeptDataScope(user);
         Integer deptid = user.getDeptid();
         if (deptDataScope.contains(deptid)) {
             return;


### PR DESCRIPTION
**问题**
    用户部门信息修改后，引起用户列表展示数据错误，修改触发异常
**原因追溯**
    用户登陆后，用户的登陆信息token，和用户所关联的信息被存放到Subject变量中。
    用户修改部门信息后，获取用户类表，和修改用户信息操作，都是通过调用ShiroUser.getUser
    获取用户的信息。而这个信息在修改用户信息时并没有被更新，所以产生异常
**解决**
    方法一：
    一种方法是修改用户信息时，更新Subject中关联的ShiroUser信息
    方法二：
    每次获取用户信息，不是区Subject中去拿，而是通过拿到UserId，然后数据库查出最新的User信息
    :: 这里我采用的是第二种处理方法


    
